### PR TITLE
allow custom flag settings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,3 +22,13 @@
       show_root_heading: false
       show_root_toc_entry: false
       show_source: false
+
+::: unpackqa.tools.validation
+    selection:
+        members:
+            - InvalidProductSpec
+        docstring_style: numpy
+    rendering:
+      show_root_heading: false
+      show_root_toc_entry: false
+      show_source: false

--- a/docs/custom_spec.md
+++ b/docs/custom_spec.md
@@ -1,0 +1,72 @@
+## Custom QA Specification
+
+If you have a QA band that is not configured in this package you can manually specify how it should be unpacked. 
+
+You can do this by setting up a dictionary with the following three entries:
+
+- `flag_info`: another dictionary where each entry represents a single flag. Each key is the name of the the flag, with the value a list of the flags designated bits.
+- `num_bits`: the number of bits in the flag. this is usually 8 or 16. 
+- `max_value`: the maximum value expected in the QA band, this will usually be (2**num_bits)-1
+
+The following example is an 8 bit QA band with 3 flags. Flags 1 and 2 are bits 0 and 1, flag 3 is spread across bits 4 and 5 (and thus can have the final values 0-3). 
+Bits 3 and 6-8 are ignored. 
+
+```
+
+custom_product_info = {'flag_info':{'flag1_description':[0],
+                                    'flag2_description':[1],
+                                    'flag3_description':[4,5]},
+                       'max_value' : 255,
+                       'num_bits'  : 8}
+```
+
+This can now be used directly in the unpack functions. The `flags` argument can be left as the default, and all specified flags will be returned. In `unpack_to_array` the
+order of the mask axis is the same as the flag order specified.
+
+```
+import numpy as np
+import unpackqa
+qa_array = np.array([[9,32],[9,2]])
+
+mask_array = unpackqa.unpack_to_array(qa_array, product=custom_product_info)
+qa_array.shape
+(2, 2)
+mask_array.shape                                                                                                                                                             
+(2, 2, 3)
+mask_array
+array([[[1, 0, 0],
+        [0, 0, 2]],
+
+       [[1, 0, 0],
+        [0, 1, 0]]], dtype=uint8)
+
+```
+With `unpack_to_dict` the resulting dictionary keys will be the flag names specified. 
+
+```
+mask_dict = unpackqa.unpack_to_dict(qa_array, product=custom_product_info) 
+mask_dict
+{'flag1_description': array([[1, 0],
+                             [1, 0]], dtype=uint8),
+ 'flag2_description': array([[0, 0],
+                             [0, 1]], dtype=uint8),
+ 'flag3_description': array([[0, 2],
+                             [0, 0]], dtype=uint8)}
+
+```
+
+## Notes  
+- the `flag_info` entry should be orderd from lowest to highest bit.
+- Flag descriptions should be short, not start with numbers, and not contain spaces or any special characters (underscores are ok). 
+While unpackqa will not object to any of those, it is easy for the descriptions to end up as column names in data.frames where they 
+can be difficult to work with if spaces, leading numbers, etc. are included. 
+- bit entries cannot be empty, negative, or exceed `num_bits`. For example all the following bit entries are invalid.
+
+```
+product_info = {'flag_info':{'flag1_description':[],
+                             'flag2_description':[-1],
+                             'flag3_description':[12]},
+                'max_value' : 255,
+                'num_bits'  : 8}
+```
+

--- a/docs/custom_spec.md
+++ b/docs/custom_spec.md
@@ -56,7 +56,7 @@ mask_dict
 ```
 
 ## Notes  
-- the `flag_info` entry should be orderd from lowest to highest bit.
+- the `flag_info` entries should be orderd from lowest to highest bit.
 - Flag descriptions should be short, not start with numbers, and not contain spaces or any special characters (underscores are ok). 
 While unpackqa will not object to any of those, it is easy for the descriptions to end up as column names in data.frames where they 
 can be difficult to work with if spaces, leading numbers, etc. are included. 
@@ -69,4 +69,4 @@ product_info = {'flag_info':{'flag1_description':[],
                 'max_value' : 255,
                 'num_bits'  : 8}
 ```
-
+- Invalid custom specification will raise the error `unpackqa.InvalidProductSpec`

--- a/docs_readme.md
+++ b/docs_readme.md
@@ -14,6 +14,9 @@ You need the following to build the docs.
 ### Making updates to the product descriptions.
 These edits should made to the yaml files in `unpackqa/product_files/` in the `description` entry. If you make an edit, run `render_product_markdown_files.py` to produce new markdown files in the `docs` folder, which will be picked up by mkdocs.
 
+### Making edits to API page
+The API page is pulled from the docstrings within each respective function via the mkdocstrings plugin. `docs/api.md` configures how those docstrings are read and displayed. 
+
 ### Making edits to any other docs
 You can edit everything else in `docs` directly.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
     - Products':
         - 'Landsat': 'Landsat.md'
         - 'MODIS': 'MODIS.md'
+        - 'Custom QA': 'custom_spec.md'
     - API Reference: 'api.md' 
     - 'GitHub Repo': 'https://github.com/sdtaylor/unpackqa'
 

--- a/test/test_custom_flags.py
+++ b/test/test_custom_flags.py
@@ -79,6 +79,18 @@ invalid_test_cases = [
                   'flag3_description':[4,5]},
      'max_value' : 500,
      'num_bits'  : 8},
+
+    # missing num_bits
+    {'flag_info':{'flag1_description':[0],
+                  'flag2_description':[1],
+                  'flag3_description':[4,5]},
+     'max_value' : 500},
+
+    # missing max_value
+    {'flag_info':{'flag1_description':[0],
+                  'flag2_description':[1],
+                  'flag3_description':[4,5]},
+     'num_bits'  : 8},
     ]
 
 

--- a/test/test_custom_flags.py
+++ b/test/test_custom_flags.py
@@ -1,0 +1,111 @@
+import pytest
+import numpy as np
+
+from unpackqa import (unpack_to_array,
+                        unpack_to_dict, 
+                        list_products,
+                        list_qa_flags
+                        )
+
+from unpackqa import InvalidProductSpec
+
+
+"""
+Custom flag specifications are allowed. Here test that capability with some
+simple flag specs, and test the internal spec validations with some
+invalid flag specs. 
+"""
+
+qa_array = np.array([[8,8,8],
+                     [16,16,16],
+                     [255,255,255]])
+
+
+
+valid_test_cases = [
+    {'flag_info':{'flag1_description':[0],
+                  'flag2_description':[1],
+                  'flag3_description':[14]},
+     'max_value' : 65535,
+     'num_bits'  : 16},   
+
+    {'flag_info':{'flag1_description':[0],
+                  'flag2_description':[1],
+                  'flag3_description':[3]},
+     'max_value' : 255,
+     'num_bits'  : 8},  
+
+    {'flag_info':{'flag1_description':[0],
+                  'flag2_description':[1],
+                  'flag3_description':[4,5]},
+     'max_value' : 255,
+     'num_bits'  : 8},    
+    
+    ]
+
+
+invalid_test_cases = [
+    # bits out of order
+    {'flag_info':{'flag1_description':[1],
+                  'flag2_description':[0],
+                  'flag3_description':[14]},
+     'max_value' : 65535,
+     'num_bits'  : 16},   
+
+    # bits too large for num_bits
+    {'flag_info':{'flag1_description':[0],
+                  'flag2_description':[1],
+                  'flag3_description':[16]},
+     'max_value' : 255,
+     'num_bits'  : 8},  
+
+    # empty flag entry
+    {'flag_info':{'flag1_description':[0],
+                  'flag2_description':[],
+                  'flag3_description':[4,5]},
+     'max_value' : 255,
+     'num_bits'  : 8},    
+    
+    # negative bit entry
+    {'flag_info':{'flag1_description':[0],
+                  'flag2_description':[-1],
+                  'flag3_description':[4,5]},
+     'max_value' : 255,
+     'num_bits'  : 8},    
+
+    # max size does not match num_bits
+    {'flag_info':{'flag1_description':[0],
+                  'flag2_description':[1],
+                  'flag3_description':[4,5]},
+     'max_value' : 500,
+     'num_bits'  : 8},
+    ]
+
+
+@pytest.mark.parametrize('custom_spec', valid_test_cases)
+def test_valid_spec_to_array(custom_spec):
+    """Custom specs result in correctly shaped array"""
+    output = unpack_to_array(qa_array, product = custom_spec)
+    n_flags = len(custom_spec['flag_info'])
+    assert output.shape == qa_array.shape + (n_flags,)
+
+@pytest.mark.parametrize('custom_spec', valid_test_cases)
+def test_valid_spec_to_dict(custom_spec):
+    """Custom specs result in correct dictionary"""
+    output = unpack_to_dict(qa_array, product = custom_spec)
+    flag_names = custom_spec['flag_info'].keys()
+    
+    flags_present = [f in output for f in flag_names]
+    assert all(flags_present)
+
+@pytest.mark.parametrize('custom_spec', invalid_test_cases)
+def test_invalid_spec_to_array(custom_spec):
+    """Invalid specs should throw an error"""
+    with pytest.raises(InvalidProductSpec):
+        output = unpack_to_dict(qa_array, product = custom_spec)
+
+@pytest.mark.parametrize('custom_spec', invalid_test_cases)
+def test_invalid_spec_to_dict(custom_spec):
+    """Invalid specs should throw an error"""
+    with pytest.raises(InvalidProductSpec):
+        output = unpack_to_dict(qa_array, product = custom_spec)

--- a/unpackqa/__init__.py
+++ b/unpackqa/__init__.py
@@ -9,9 +9,13 @@ from .unpack import (unpack_to_array,
                      unpack_to_dict,
                      )
 
+# Make this available to catch exceptions
+from .tools.validation import InvalidProductSpec
+
 __all__ = ['list_sensors',
            'list_products',
            'list_qa_flags',
            'unpack_to_array',
            'unpack_to_dict',
+           'InvalidProductSpec',
            ]

--- a/unpackqa/tools/validation.py
+++ b/unpackqa/tools/validation.py
@@ -1,7 +1,9 @@
 
 
 class InvalidProductSpec(ValueError):
-    """Something is incorrect with the bit flag specification"""
+    """
+    Error class for when an invalid custom specification is passed to the `product` argument.
+    """
 
 # Tests to validate custom product flag specifications. These specs can be declared
 # via a dictionary in the unpack_to_* functions.

--- a/unpackqa/tools/validation.py
+++ b/unpackqa/tools/validation.py
@@ -1,0 +1,103 @@
+
+
+class InvalidProductSpec(ValueError):
+    """Something is incorrect with the bit flag specification"""
+
+# Tests to validate custom product flag specifications. These specs can be declared
+# via a dictionary in the unpack_to_* functions.
+# These tests are also used validate the internally configured products during self testing.
+
+def product_info_is_dict(product_info):
+    if not isinstance(product_info, dict):
+            raise TypeError('product info should be a dictonary')
+
+def product_info_has_required_entries(product_info):
+    required_entries = ['flag_info','num_bits','max_value']
+    if not all([e in product_info for e in required_entries]):
+        raise InvalidProductSpec('product info missing required entires')
+
+def flag_info_is_non_empty_dict(product_info):
+    flag_info = product_info['flag_info']
+    if not isinstance(flag_info, dict) and len(flag_info) > 0:
+        raise InvalidProductSpec('flag_info entry should be non-empty dictionary')
+
+def flag_info_bit_list_non_empty(product_info):
+    """Bit entries for each flag a non-empty lists"""
+    flags_valid = []
+    for flag_name, bits in product_info['flag_info'].items():
+        flags_valid.append(isinstance(bits, list) and len(bits) > 0)
+    if not all(flags_valid):
+        raise InvalidProductSpec('bit entries for each flag should be non-empty lists')
+        
+def flag_info_bits_non_neg_ints(product_info):
+    """Bits within each list should be non-negative integers"""
+    flags_valid = []
+    for flag_name, bits in product_info['flag_info'].items():
+        bits_non_neg = all([b >=0 for b in bits])
+        bits_values_are_ints = all([isinstance(b,int) for b in bits])
+        flags_valid.append(bits_non_neg and bits_values_are_ints)
+    if not all(flags_valid):
+        raise InvalidProductSpec('bits should be non-negative integers')
+        
+def flag_info_flag_is_str(product_info):
+    """The key values within 'flag_info' should be strings"""
+    flags_valid = []
+    for flag_name, bits in product_info['flag_info'].items():
+        flags_valid.append(isinstance(flag_name,str))
+    if not all(flags_valid):
+        raise InvalidProductSpec('flag descriptions should be strings')
+        
+def bits_are_only_used_once(product_info):
+    """Bits should not be listed twice"""
+    all_listed_bits = []
+    for flag_name, bits in product_info['flag_info'].items():
+        all_listed_bits.extend(bits)
+        
+    if not len(set(all_listed_bits)) == len(all_listed_bits):
+        raise InvalidProductSpec('duplicate bits detected')
+
+def bits_are_reasonable(product_info):
+    """Very unlikely to encounter anything beyond 32 bit integers for masks"""
+    all_listed_bits = []
+    for flag_name, bits in product_info['flag_info'].items():
+        all_listed_bits.extend(bits)
+        
+    if not all([b <= 32 for b in all_listed_bits]):
+        raise InvalidProductSpec('Bits greater than 32 listed')
+
+def bits_do_not_exceed_bit_size(product_info):
+    """The largest bit should be <= the number of bits"""
+    all_listed_bits = []
+    for flag_name, bits in product_info['flag_info'].items():
+        all_listed_bits.extend(bits)
+        
+    if not max(all_listed_bits) < product_info['num_bits']:
+        raise InvalidProductSpec('Largest bit flag is greater than num_bits')
+        
+def max_value_matches_num_bits(product_info):
+    """ Maximum value listed should be < the largest size given num_bits"""
+    if product_info['max_value'] >= 2**product_info['num_bits']:
+        raise InvalidProductSpec('max_value is >= 2**num_bits')
+        
+def bits_are_ordered(product_info):
+    """Bits should be listed smallest to largest"""
+    all_listed_bits = []
+    for flag_name, bits in product_info['flag_info'].items():
+        all_listed_bits.extend(bits)
+        
+    if not all_listed_bits == sorted(all_listed_bits):
+        raise InvalidProductSpec('bits are not listed smallest to largest')
+
+def validate_product_spec(product_info):
+    """Used in user facing functions to check custom speciifcaitons"""
+    product_info_is_dict(product_info)
+    product_info_has_required_entries(product_info)
+    flag_info_is_non_empty_dict(product_info)
+    flag_info_bit_list_non_empty(product_info)
+    flag_info_bits_non_neg_ints(product_info)
+    flag_info_flag_is_str(product_info)
+    bits_are_only_used_once(product_info)
+    bits_are_reasonable(product_info)
+    bits_do_not_exceed_bit_size(product_info)
+    max_value_matches_num_bits(product_info)
+    bits_are_ordered(product_info)

--- a/unpackqa/unpack.py
+++ b/unpackqa/unpack.py
@@ -24,11 +24,13 @@ def unpack_to_array(qa, product, flags='all'):
         The order of the mask axis in the returned array will be the same as
         the flag order specifed here. 
         
+        ```
         product_info = {'flag_info':{'flag1_description':[0],
                                      'flag2_description':[1],
                                      'flag3_description':[4,5]},
                         'max_value' : 255,
                         'num_bits'  : 8}
+        ```
         
     flags : list of strings or 'all', optional
         List of flags to return. If 'all', the default, then all available
@@ -78,12 +80,16 @@ def unpack_to_dict(qa, product, flags='all'):
         so is assumed unused. `max_value` is generally set to the maximum possible
         value given the bit size. If this option is used then the `flags` 
         argument can be left as the default `all`.  
+        The resulting dictionary key names will be the same as the flag
+        descriptions specified here.
         
+        ```
         product_info = {'flag_info':{'flag1_description':[0],
                                      'flag2_description':[1],
                                      'flag3_description':[4,5]},
                         'max_value' : 255,
                         'num_bits'  : 8}
+        ```
         
     flags : list of strings or 'all', optional
         List of flags to return. If 'all', the default, then all available

--- a/unpackqa/unpack.py
+++ b/unpackqa/unpack.py
@@ -18,11 +18,11 @@ def unpack_to_array(qa, product, flags='all'):
         A custom bit flag specification may also be used via a dictionary.
         For example, below is an 8 bit qa flag where the 1st and 2nd flags are bits 0 and 1,
         and the 3rd flag is spread across bits 4 and 5. Note bit 3 is not specified
-        so is assumed unused. `max_value` is generally set to the maximum possible
+        so is ignored. `max_value` is generally set to the maximum possible
         value given the bit size. If this option is used then the `flags` 
         argument can be left as the default `all`.  
-        The order of the mask axis in the returned array will be the same as
-        the flag order specifed here. 
+        Flags should be ordered from lowest to highest bits. The order of the mask axis
+        in the returned array will be the same as the flag order specifed here. 
         
         ```
         product_info = {'flag_info':{'flag1_description':[0],
@@ -80,8 +80,8 @@ def unpack_to_dict(qa, product, flags='all'):
         so is assumed unused. `max_value` is generally set to the maximum possible
         value given the bit size. If this option is used then the `flags` 
         argument can be left as the default `all`.  
-        The resulting dictionary key names will be the same as the flag
-        descriptions specified here.
+        Flags should be ordered from lowest to highest bits. The resulting dictionary
+        key names will be the same as the flag descriptions specified here.
         
         ```
         product_info = {'flag_info':{'flag1_description':[0],

--- a/unpackqa/unpack.py
+++ b/unpackqa/unpack.py
@@ -1,5 +1,6 @@
 from .base import UnpackQABase
 from .product_loader import all_products
+from .tools.validation import validate_product_spec
 
 def unpack_to_array(qa, product, flags='all'):
     """
@@ -11,8 +12,24 @@ def unpack_to_array(qa, product, flags='all'):
     qa : np.array or int
         An array of any shape with an int-like dtype. If a single integer 
         it will be coverted to a numpy array with length 1. 
-    product : str
-        A unique product identifer. See `list_products()` for availability.
+    product : str or dict
+        A unique product identifer string. See `list_products()` for availability.
+        
+        A custom bit flag specification may also be used via a dictionary.
+        For example, below is an 8 bit qa flag where the 1st and 2nd flags are bits 0 and 1,
+        and the 3rd flag is spread across bits 4 and 5. Note bit 3 is not specified
+        so is assumed unused. `max_value` is generally set to the maximum possible
+        value given the bit size. If this option is used then the `flags` 
+        argument can be left as the default `all`.  
+        The order of the mask axis in the returned array will be the same as
+        the flag order specifed here. 
+        
+        product_info = {'flag_info':{'flag1_description':[0],
+                                     'flag2_description':[1],
+                                     'flag3_description':[4,5]},
+                        'max_value' : 255,
+                        'num_bits'  : 8}
+        
     flags : list of strings or 'all', optional
         List of flags to return. If 'all', the default, then all available
         flags are returned in the array. See available flags for each 
@@ -30,6 +47,11 @@ def unpack_to_array(qa, product, flags='all'):
         `available_qa_flags`, which are be aligned with the flag bit order.
 
     """
+    if isinstance(product, dict):
+        validate_product_spec(product)
+        base = UnpackQABase(product)
+        return base._unpack_to_array(qa, flags=flags)
+    
     if product in all_products:
         product_info = all_products[product]
         base = UnpackQABase(product_info)
@@ -47,8 +69,22 @@ def unpack_to_dict(qa, product, flags='all'):
     qa : np.array or int
         An array of any shape with an int-like dtype. If a single integer 
         it will be coverted to a numpy array with length 1. 
-    product : str
-        A unique product identifer. See `list_products()` for availability.
+    product : str or dict
+        A unique product identifer string. See `list_products()` for availability.
+        
+        A custom bit flag specification may also be used via a dictionary.
+        For example, below is an 8 bit qa flag where the 1st and 2nd flags are bits 0 and 1,
+        and the 3rd flag is spread across bits 4 and 5. Note bit 3 is not specified
+        so is assumed unused. `max_value` is generally set to the maximum possible
+        value given the bit size. If this option is used then the `flags` 
+        argument can be left as the default `all`.  
+        
+        product_info = {'flag_info':{'flag1_description':[0],
+                                     'flag2_description':[1],
+                                     'flag3_description':[4,5]},
+                        'max_value' : 255,
+                        'num_bits'  : 8}
+        
     flags : list of strings or 'all', optional
         List of flags to return. If 'all', the default, then all available
         flags are returned in the array. See available flags for each 
@@ -62,6 +98,11 @@ def unpack_to_dict(qa, product, flags='all'):
         same shape.
 
     """
+    if isinstance(product, dict):
+        validate_product_spec(product)
+        base = UnpackQABase(product)
+        return base._unpack_to_dict(qa, flags=flags)
+    
     if product in all_products:
         product_info = all_products[product]
         base = UnpackQABase(product_info)


### PR DESCRIPTION
now a user can define flags for themselves if one isn't configured.

the UnpackQABase class just needs a valid dictionary to do this, so
making custom specs possible is mostly just ensuring the spec is valid.

I essentially just moved all the product tests to internal validation
functions and added a few more. The tests in test/test_products.py now
just call those same ones instead of repeating things.

Also:
- A few new tests to verify the custom spec capability
- new docstrings for user facing functions
- an error class for bad flag specs